### PR TITLE
accept_cookies from 'Accept' to 'Accept All'

### DIFF
--- a/instadm.py
+++ b/instadm.py
@@ -16,7 +16,7 @@ class InstaDM(object):
 
     def __init__(self, username, password, headless=True, instapy_workspace=None, profileDir=None):
         self.selectors = {
-            "accept_cookies": "//button[text()='Accept']",
+            "accept_cookies": "//button[text()='Accept All']",
             "home_to_login_button": "//button[text()='Log In']",
             "username_field": "username",
             "password_field": "password",


### PR DESCRIPTION
Hi there!

As I was trying out this bot in headless mode, I came across the following error: 

```console
Timed out. Element not found with XPATH : //button[text()='Accept']
```

I noticed that Instagram uses now  'Accept All' instead of just 'Accept' in their cookie confirmation button.

![instagram-bot-dm-pr-selector](https://user-images.githubusercontent.com/47882572/131543104-56928a3b-166f-4e93-b88c-c9b0bdc72515.png)

Upon fixing this locally, the bot worked perfectly fine. 

Tested on:
- OS X Big Sur 11.4 with Google Chrome 92.0.4515.159
- Ubuntu 20.04.2 LTS with chromium-chromedriver 85.0.4183.83

