### PR TITLE
Fix "This browser is not longer supported" banner for some browser driver versions

### DIFF
--- a/instadm.py
+++ b/instadm.py
@@ -126,6 +126,18 @@ class InstaDM(object):
             self.__random_sleep__()
 
         if self.__wait_for_element__(self.selectors['send'], "xpath"):
+            element = self.__get_element__('rh7Wz', 'CLASS')
+                if element is not None:
+                    self.driver.execute_script("""
+                                    var element = arguments[0];
+                                    element.parentNode.removeChild(element);
+                                    """, element)
+                element = self.__get_element__('vohlx', 'CLASS')
+                if element is not None:
+                    self.driver.execute_script("""
+                                    var element = arguments[0];
+                                    element.parentNode.removeChild(element);
+                                    """, element)
             self.__get_element__(self.selectors['send'], "xpath").click()
             self.__random_sleep__(3, 5)
             print('Message sent successfully')
@@ -265,6 +277,8 @@ class InstaDM(object):
                 return WebDriverWait(dr, 15).until(lambda d: dr.find_element_by_xpath(element_tag))
             elif locator == 'CSS' and self.is_element_present(By.CSS_SELECTOR, element_tag):
                 return WebDriverWait(dr, 15).until(lambda d: dr.find_element_by_css_selector(element_tag))
+            elif locator == 'CLASS' and self.is_element_present(By.CLASS_NAME, element_tag):
+                return WebDriverWait(dr, 15).until(lambda d: dr.find_element_by_class_name(element_tag))
             else:
                 logging.info(f"Error: Incorrect locator = {locator}")
         except Exception as e:

--- a/instadm.py
+++ b/instadm.py
@@ -126,7 +126,7 @@ class InstaDM(object):
             self.__random_sleep__()
 
         if self.__wait_for_element__(self.selectors['send'], "xpath"):
-            __remove_browser_unsupported_banner_if_exists(self, element):
+            self.__remove_browser_unsupported_banner_if_exists(self, element):
             self.__get_element__(self.selectors['send'], "xpath").click()
             self.__random_sleep__(3, 5)
             print('Message sent successfully')

--- a/instadm.py
+++ b/instadm.py
@@ -126,18 +126,7 @@ class InstaDM(object):
             self.__random_sleep__()
 
         if self.__wait_for_element__(self.selectors['send'], "xpath"):
-            element = self.__get_element__('rh7Wz', 'CLASS')
-            if element is not None:
-                self.driver.execute_script("""
-                                    var element = arguments[0];
-                                    element.parentNode.removeChild(element);
-                                    """, element)
-            element = self.__get_element__('vohlx', 'CLASS')
-            if element is not None:
-                self.driver.execute_script("""
-                                    var element = arguments[0];
-                                    element.parentNode.removeChild(element);
-                                    """, element)
+            __remove_browser_unsupported_banner_if_exists(self, element):
             self.__get_element__(self.selectors['send'], "xpath").click()
             self.__random_sleep__(3, 5)
             print('Message sent successfully')
@@ -352,3 +341,17 @@ class InstaDM(object):
     def teardown(self):
         self.driver.close()
         self.driver.quit()
+
+    def __remove_browser_unsupported_banner_if_exists(self, element):
+        element = self.__get_element__('rh7Wz', 'CLASS')
+        if element is not None:
+            self.driver.execute_script("""
+                                var element = arguments[0];
+                                element.parentNode.removeChild(element);
+                                """, element)
+        element = self.__get_element__('vohlx', 'CLASS')
+        if element is not None:
+            self.driver.execute_script("""
+                                var element = arguments[0];
+                                element.parentNode.removeChild(element);
+                                """, element)

--- a/instadm.py
+++ b/instadm.py
@@ -127,14 +127,14 @@ class InstaDM(object):
 
         if self.__wait_for_element__(self.selectors['send'], "xpath"):
             element = self.__get_element__('rh7Wz', 'CLASS')
-                if element is not None:
-                    self.driver.execute_script("""
+            if element is not None:
+                self.driver.execute_script("""
                                     var element = arguments[0];
                                     element.parentNode.removeChild(element);
                                     """, element)
-                element = self.__get_element__('vohlx', 'CLASS')
-                if element is not None:
-                    self.driver.execute_script("""
+            element = self.__get_element__('vohlx', 'CLASS')
+            if element is not None:
+                self.driver.execute_script("""
                                     var element = arguments[0];
                                     element.parentNode.removeChild(element);
                                     """, element)


### PR DESCRIPTION
Hi! "This browser is not longer supported" banner caused problems if the message to be sent was long enough that the "send" button got under it, causing the click to send to raise an error. 
This fix removes the divs that are causing problems.
Certainly there are cleaner ways of doing this but I don't have enough experience in selenium or front-end dev :)